### PR TITLE
Collect static in docker entry point

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.coverage
+htmlcov
+.vscode
+.github
+.pytest_cache
+staticfiles
+.env
+.gitignore
+docs
+**/__pycache__
+**/.DS_Store
+.git
+.devcontainer

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,4 +30,5 @@ done
 >&2 echo 'PostgreSQL is available'
 
 /venv/bin/python manage.py migrate
+/venv/bin/python manage.py collectstatic
 /venv/bin/gunicorn --workers 3 --bind 0.0.0.0:5000 --forwarded-allow-ips='*' config.wsgi:application


### PR DESCRIPTION
- Call collectstatic on container start, after migrations
- Add .dockerignore to prevent cruft from getting in docker images