### PR TITLE
Fix dev dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -332,7 +332,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.11"
-content-hash = "174b9ca07b3b54b79143e4ef9d8d1d3880984323bf05cb4b90dc0c45020095bf"
+content-hash = "d266873df3b12d463bd635daa90a78b1e2aae3f3649f5f448e0b7700bf34330b"
 
 [metadata.files]
 argon2-cffi = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ bleach-allowlist = "^1.0.3"
 boto3 = "^1.26.22"
 django-storages = "^1.13.1"
 
-[tool.poetry.dev-dependencies]
-django-debug-toolbar = ">=2.1"
+[tool.poetry.group.dev.dependencies]
+django-debug-toolbar = "^3.8.1"
 
 [tool.pytest.ini_options]
 python_files = ["tests.py", "test_*.py", "*_tests.py"]


### PR DESCRIPTION
Now uses a group-based method:

https://python-poetry.org/docs/managing-dependencies/