### PR TITLE
Split out tox.ini configs into its own file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,51 +64,6 @@ exclude = """
 profile = "black"
 skip_glob = ["docs/*", "*/migrations/*"]
 
-[tool.tox]
-legacy_tox_ini = """
-[tox]
-envlist = py311
-isolated_build = True
-
-[testenv]
-usedevelop = True
-
-[testenv:{test,coverage,coverage-html}]
-setenv = 
-    DJANGO_SETTINGS_MODULE=config.settings.test
-skip_install = true
-allowlist_externals = poetry
-commands_pre = 
-    poetry install
-commands:
-    test: poetry run pytest
-    coverage: poetry run coverage run -m pytest
-    coverage-html: poetry run coverage html
-
-[testenv:lint]
-skip_install = true
-deps =
-    flake8
-commands =
-    flake8
-
-[testenv:{check-format,black}]
-skip_install = true
-deps =
-    black
-commands =
-    check-format: black . --check --diff
-    black: black .
-
-[testenv:{check-imports,isort}]
-skip_install = true
-deps =
-    isort
-commands =
-    check-imports: isort . --check-only
-    isort: isort .
-"""
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,41 @@
+[tox]
+envlist = py311
+isolated_build = True
+
+[testenv]
+usedevelop = True
+
+[testenv:{test,coverage,coverage-html}]
+setenv = 
+    DJANGO_SETTINGS_MODULE=config.settings.test
+skip_install = true
+allowlist_externals = poetry
+commands_pre = 
+    poetry install
+commands:
+    test: poetry run pytest
+    coverage: poetry run coverage run -m pytest
+    coverage-html: poetry run coverage html
+
+[testenv:lint]
+skip_install = true
+deps =
+    flake8
+commands =
+    flake8
+
+[testenv:{check-format,black}]
+skip_install = true
+deps =
+    black
+commands =
+    check-format: black . --check --diff
+    black: black .
+
+[testenv:{check-imports,isort}]
+skip_install = true
+deps =
+    isort
+commands =
+    check-imports: isort . --check-only
+    isort: isort .


### PR DESCRIPTION
It being an ini inside the string of another file buys me nothing now that the root has been cleaned up. Having it in its own file makes pyproject.toml more readable and gives syntax highlighting for the ini